### PR TITLE
ci/cd: fix integration test

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('home page has expected h1', async ({ page }) => {
+test('home page has expected appShell', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.locator('h1')).toBeVisible();
+	await expect(page.locator('#appShell')).toBeVisible();
 });


### PR DESCRIPTION
When running `npm run test:integration` locally (which in turn calls `playwright test`), I noticed that our integration tests were failing. 

In particular, the test was searching for an `h1` element at the root page, however none exists. 
I updated the test to instead expect the `appShell` div to be available in the home page. 

The test is still simple, and mainly representative, but it should now pass. 

Relates to #25 