### PR TITLE
Scenario source and equity market selectors data driven

### DIFF
--- a/src/routes/sector_view.svelte
+++ b/src/routes/sector_view.svelte
@@ -54,6 +54,31 @@
 			assetClasses.forEach((assetClass) => assetClassSelector.add(new Option(assetClass, assetClass)));
 		};
 
+		function updateScenarioSourceSelector() {
+			let selectedSource = document.querySelector('#scenario_source_selector').value;
+
+			let selectedClass = document.querySelector('#asset_class_selector').value;
+			let selectedSector = document.querySelector('#sector_selector').value;
+
+			let filteredTechmixData = techmix_data
+				.filter((d) => d.asset_class == selectedClass)
+				.filter((d) => d.ald_sector == selectedSector);
+			let scenarioSourcesTechMix = new Set(d3.map(filteredTechmixData, (d) => d.scenario_source).keys());
+
+			let filteredVolTrajData = traj_data
+				.filter((d) => d.asset_class == selectedClass)
+				.filter((d) => d.ald_sector == selectedSector);
+			let scenarioSourcesVolTraj = new Set(d3.map(filteredVolTrajData, (d) => d.scenario_source).keys());
+
+			let scenarioSources = Array.from(scenarioSourcesTechMix.union(scenarioSourcesVolTraj));
+
+			const scenarioSourceSelector = document.querySelector('#scenario_source_selector');
+			scenarioSourceSelector.length = 0;
+			scenarioSources.forEach((source) => scenarioSourceSelector.add(new Option(source, source)));
+			scenarioSourceSelector.options[Math.max(0, scenarioSources.indexOf(selectedSource))].selected =
+				'selected';
+		}
+
 		function updateScenarioSelector() {
 			let selectedClass = document.querySelector('#asset_class_selector').value;
 			let selectedSector = document.querySelector('#sector_selector').value;
@@ -143,6 +168,7 @@
 			});
 
 			sector_selector.addEventListener('change', function () {
+				updateScenarioSourceSelector();
 				updateBenchmarkSelector();
 				fetchTrajectoryAlignment();
 				fetchTechmix();
@@ -150,6 +176,7 @@
 			});
 
 			asset_class_selector.addEventListener('change', function () {
+				updateScenarioSourceSelector();
 				updateAllocationMethodSelector();
 				updateBenchmarkSelector();
 				fetchTrajectoryAlignment();
@@ -187,6 +214,7 @@
 
 		setValuesSectorSelectors();
 		setValuesAssetClassSelector();
+		updateScenarioSourceSelector();
 		updateScenarioSelector();
 		updateAllocationMethodSelector();
 		updateBenchmarkSelector();
@@ -298,11 +326,12 @@
 				<h4 class="h4">Parameters</h4>
 				<br />
 				<label class="label">
-					<span>Scenario source</span>
+					<span id="scenario-source-label">Scenario source &#9432</span>
+					<div class="hide dashboard-tooltip card p-4 shadow-xl">
+						Applies to the technology mix and production volume alignment plots.
+					</div>
 					<select class="select variant-outline-surface" id="scenario_source_selector">
-						<option value="WEO2023">WEO2023</option>
-						<option value="GECO2023">GECO2023</option>
-						<option value="ISF2023">ISF2023</option>
+						<option value="Not_selected">Please select</option>
 					</select>
 				</label>
 				<label class="label">
@@ -348,6 +377,10 @@
 <style>
 	.hide {
 		display: none;
+	}
+
+	#scenario-source-label:hover + .hide {
+		display: inline-block;
 	}
 
 	#scenario-label:hover + .hide {

--- a/src/routes/sector_view.svelte
+++ b/src/routes/sector_view.svelte
@@ -194,6 +194,7 @@
 
 			sector_selector.addEventListener('change', function () {
 				updateScenarioSourceSelector();
+				updateScenarioSelector();
 				updateEquityMarketSelector();
 				updateBenchmarkSelector();
 				fetchTrajectoryAlignment();
@@ -203,6 +204,7 @@
 
 			asset_class_selector.addEventListener('change', function () {
 				updateScenarioSourceSelector();
+				updateScenarioSelector();
 				updateAllocationMethodSelector();
 				updateEquityMarketSelector();
 				updateBenchmarkSelector();

--- a/src/routes/sector_view.svelte
+++ b/src/routes/sector_view.svelte
@@ -121,6 +121,31 @@
 				'selected';
 		};
 
+		function updateEquityMarketSelector() {
+			let selectedMarket = document.querySelector('#equity_market_selector').value;
+
+			let selectedClass = document.querySelector('#asset_class_selector').value;
+			let selectedSector = document.querySelector('#sector_selector').value;
+
+			let filteredTechmixData = techmix_data
+				.filter((d) => d.asset_class == selectedClass)
+				.filter((d) => d.ald_sector == selectedSector);
+			let equityMarketsTechMix = new Set(d3.map(filteredTechmixData, (d) => d.equity_market).keys());
+
+			let filteredVolTrajData = traj_data
+				.filter((d) => d.asset_class == selectedClass)
+				.filter((d) => d.ald_sector == selectedSector);
+			let equityMarketsVolTraj = new Set(d3.map(filteredVolTrajData, (d) => d.equity_market_translation).keys());
+
+			let equityMarkets = Array.from(equityMarketsTechMix.union(equityMarketsVolTraj));
+
+			const equityMarketSelector = document.querySelector('#equity_market_selector');
+			equityMarketSelector.length = 0;
+			equityMarkets.forEach((market) => equityMarketSelector.add(new Option(market, market)));
+			equityMarketSelector.options[Math.max(0, equityMarkets.indexOf(selectedMarket))].selected =
+				'selected';
+		};
+
 		function updateBenchmarkSelector() {
 			let selectedBenchmark = document.querySelector('#benchmark_selector').value;
 
@@ -169,6 +194,7 @@
 
 			sector_selector.addEventListener('change', function () {
 				updateScenarioSourceSelector();
+				updateEquityMarketSelector();
 				updateBenchmarkSelector();
 				fetchTrajectoryAlignment();
 				fetchTechmix();
@@ -178,6 +204,7 @@
 			asset_class_selector.addEventListener('change', function () {
 				updateScenarioSourceSelector();
 				updateAllocationMethodSelector();
+				updateEquityMarketSelector();
 				updateBenchmarkSelector();
 				fetchTrajectoryAlignment();
 				fetchTechmix();
@@ -217,6 +244,7 @@
 		updateScenarioSourceSelector();
 		updateScenarioSelector();
 		updateAllocationMethodSelector();
+		updateEquityMarketSelector();
 		updateBenchmarkSelector();
 		addEventListeners();
 		fetchTechmix();
@@ -353,11 +381,12 @@
 					</select>
 				</label>
 				<label class="label">
-					<span>Equity market</span>
+					<span id="equity-market-label">Equity market &#9432</span>
+					<div class="hide dashboard-tooltip card p-4 shadow-xl">
+						Applies to the production volume alignment and the technology mix plots.
+					</div>
 					<select class="select variant-outline-surface" id="equity_market_selector">
-						<option value="Global Market">Global Market</option>
-						<option value="Developed Market">Developed Market</option>
-						<option value="Emerging Market">Emerging Market</option>
+						<option value="Not_selected">Please select</option>
 					</select>
 				</label>
 				<label class="label">
@@ -388,6 +417,10 @@
 	}
 
 	#allocation-method-label:hover + .hide {
+		display: inline-block;
+	}
+
+	#equity-market-label:hover + .hide {
 		display: inline-block;
 	}
 


### PR DESCRIPTION
In this PR I update two selectors

Scenario source dependent on:
* asset class
* sector

Equity market dependent on:
* asset class
* sector

I observed a weird behaviour when Automotive + Corporate bonds is selected but I believe this is due to lack of exposure to that sector/asset class combination in test portfolio. We need to investigate this further while testing and also implement a better solution when no data is present for a given combination of sector/asset class but that is a topic for another PR and I think it is captured by this PBI on ADO: https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_sprints/taskboard/P4I/2DegreesInvesting/2024_22?workitem=11659