### PR TITLE
💄 exposure_stats.js loses var `marginRight`

### DIFF
--- a/src/js/exposure_stats.js
+++ b/src/js/exposure_stats.js
@@ -24,7 +24,6 @@ export class ExposureStatsTile {
 		const width = 250;
 		const height = 120;
 		const marginTop = 10;
-		const marginRight = 5;
 		const marginBottom = 5;
 		const marginLeft = 5;
 


### PR DESCRIPTION
This var was defined but never used, so I'm just removing it entirely.

You can confirm below that this is a pure refactor:

## Before (`main`)
<img width="252" alt="Screenshot 2024-12-02 at 15 12 33" src="https://github.com/user-attachments/assets/071654ae-594c-4dfa-adc6-52a9aaca8161">

## After (this PR)
<img width="244" alt="Screenshot 2024-12-02 at 15 13 34" src="https://github.com/user-attachments/assets/c8889b8e-5274-41f8-ad77-679b1d0da865">

@MonikaFu FYI

Relates to #96 
Towards #29 