### PR TITLE
💄 included_table.js loses var `cells`

### DIFF
--- a/src/js/included_table.js
+++ b/src/js/included_table.js
@@ -47,7 +47,7 @@ export function tabulateIntoIncludedTable(data, id, opts) {
 
 	var rows = tbody.selectAll('tr').data(data).enter().append('tr');
 
-	var cells = rows
+	rows
 		.selectAll('td')
 		.data((row) => {
 			return columns.map((column) => {


### PR DESCRIPTION
This var was being defined for it's side effects, and is never actually called after being defined, causing the linter to complain. 

By removing the var definition, we still benefit from the desired side effects of calling each method on `rows`. 

You can confirm below that this is a pure refactor:

## Before (`main`)
<img width="648" alt="Screenshot 2024-12-02 at 15 20 58" src="https://github.com/user-attachments/assets/a69a29a4-8e71-422f-8697-19553f12a5cc">

## After (this PR)
<img width="640" alt="Screenshot 2024-12-02 at 15 21 39" src="https://github.com/user-attachments/assets/1f9216f3-f40f-4922-be1c-86e18c6a2b34">

@MonikaFu FYI

Relates to #96 
Towards #29 