### PR TITLE
💄 JS files lose all unused vars and imports

### DIFF
--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -158,13 +158,13 @@ export class PieExploded {
 			]);
 		var textLabels = slicelabels
 			.append('text')
-			.attr('x', function (d, i) {
+			.attr('x', function (d) {
 				return d.textx;
 			})
-			.attr('y', function (d, i) {
+			.attr('y', function (d) {
 				return d.texty;
 			})
-			.attr('text-anchor', function (d, i) {
+			.attr('text-anchor', function (d) {
 				return d.rightHalf ? 'start' : 'end';
 			})
 			.text((d) => d.data.key_translation + ' ' + prcnt_format(d.data.value / total_value))
@@ -232,11 +232,11 @@ export class PieExploded {
 				labelForLine;
 
 			again = false;
-			textLabels.each(function (d, i) {
+			textLabels.each(function () {
 				thisLabel = this;
 				thisLabelDoc = d3.select(thisLabel);
 				y1 = thisLabelDoc.attr('y');
-				textLabels.each(function (d, i) {
+				textLabels.each(function () {
 					thatLabel = this;
 					if (thisLabel == thatLabel) return;
 

--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -112,8 +112,6 @@ export class PieExploded {
 		});
 
 		data_ready.forEach(function (d) {
-			var point = point_coord(d.midAngle, radius);
-			var offset = Math.abs(d.texty - point[1]);
 			d.elbowx = d.rightHalf
 				? d.textx - text_right_offset * numberSign(d.textx)
 				: d.textx - text_left_offset * numberSign(d.textx);

--- a/src/js/techexposure.js
+++ b/src/js/techexposure.js
@@ -29,9 +29,7 @@ export class techexposure {
 		const marginLeft = 100;
 		const bar_width = 30;
 		const bar_gap = 12;
-		const sector_gap = 10;
 		const portfolio_label_offset = 25;
-		const legend_labels_offset = 50;
 
 		// Labels
 		let port_label = 'This portfolio',
@@ -416,11 +414,11 @@ export class techexposure {
 				.style('display', 'inline-block');
 		}
 
-		function mousemove(d) {
+		function mousemove() {
 			tooltip.style('left', d3.event.pageX + 10 + 'px').style('top', d3.event.pageY - 20 + 'px');
 		}
 
-		function mouseout(d) {
+		function mouseout() {
 			tooltip.style('display', 'none');
 		}
 

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -312,7 +312,7 @@ export class techexposure_company {
 		function getPortfolioWeightsPerIdData(data) {
 			let subdata_weights = [];
 
-			data.forEach((item, index) => {
+			data.forEach((item) => {
 				exist_id = false;
 				for (var i = 0; i < subdata_weights.length; i++) {
 					var exist_id = exist_id || subdata_weights[i]['id'] == item.id_translation;

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -63,7 +63,8 @@ export class techexposure_company {
 			(d) => d.ald_sector_translation == selected_sector
 		)[0]['ald_sector'];
 
-		let [subdata_up, undefined] = getDataBarsAndWeights(
+		// eslint-disable-next-line
+		let [subdata_up, _null] = getDataBarsAndWeights(
 			data_up,
 			selected_class,
 			selected_sector,

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -77,7 +77,7 @@ export class techexposure_company {
 		);
 
 		if (subdata_up.length == 0) {
-			throw new Error('No data found after applying selected filters')
+			throw new Error('No data found after applying selected filters');
 		}
 
 		// artificially add company name translations
@@ -94,7 +94,7 @@ export class techexposure_company {
 		);
 
 		if (subdata_down.length == 0) {
-			throw new Error('No data found after applying selected filters')
+			throw new Error('No data found after applying selected filters');
 		}
 
 		subdata_down = orderData(

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -488,7 +488,7 @@ export class techexposure_company {
 				.attr('technology', function (d) {
 					return getTechnologyTranslation(d.key);
 				})
-				.attr('sector', function (d) {
+				.attr('sector', function () {
 					return getSectorTranslation(sector);
 				})
 				.selectAll('rect')
@@ -546,11 +546,11 @@ export class techexposure_company {
 				.style('display', 'inline-block');
 		}
 
-		function mousemove(d) {
+		function mousemove() {
 			tooltip.style('left', d3.event.pageX + 10 + 'px').style('top', d3.event.pageY - 20 + 'px');
 		}
 
-		function mouseout(d) {
+		function mouseout() {
 			tooltip.style('display', 'none');
 		}
 	}

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -64,7 +64,7 @@ export class techexposure_company {
 		)[0]['ald_sector'];
 
 		// eslint-disable-next-line
-		let [subdata_up, _null] = getDataBarsAndWeights(
+		let [subdata_up, unused] = getDataBarsAndWeights(
 			data_up,
 			selected_class,
 			selected_sector,

--- a/src/js/techmix_sector.js
+++ b/src/js/techmix_sector.js
@@ -1,5 +1,4 @@
 import * as d3 from 'd3';
-import { union } from 'd3-array';
 import '../css/plot_styles.css';
 
 export class techmix_sector {

--- a/src/js/techmix_sector.js
+++ b/src/js/techmix_sector.js
@@ -215,7 +215,7 @@ export class techmix_sector {
 		// Add bars for green technologies
 		svg
 			.append('g')
-			.attr('transform', function (d) {
+			.attr('transform', function () {
 				return 'translate(0, ' + y0(subdataTechPerYear[0].year) + ')';
 			})
 			.selectAll()

--- a/src/js/techmix_sector.js
+++ b/src/js/techmix_sector.js
@@ -168,7 +168,7 @@ export class techmix_sector {
 		// Add rectangles for each stacked bar
 		svg
 			.append('g')
-			.attr('transform', function (d) {
+			.attr('transform', function () {
 				return 'translate(0, ' + y0(subdataTechPerYear[0].year) + ')';
 			})
 			.selectAll('g')
@@ -191,7 +191,7 @@ export class techmix_sector {
 
 		svg
 			.append('g')
-			.attr('transform', function (d) {
+			.attr('transform', function () {
 				return 'translate(0, ' + y0(subdataTechPerYear[1].year) + ')';
 			})
 			.selectAll('g')
@@ -235,7 +235,7 @@ export class techmix_sector {
 
 		svg
 			.append('g')
-			.attr('transform', function (d) {
+			.attr('transform', function () {
 				return 'translate(0, ' + y0(subdataTechPerYear[1].year) + ')';
 			})
 			.selectAll()
@@ -269,20 +269,6 @@ export class techmix_sector {
 			.call(d3.axisBottom(x).ticks(5).tickFormat(d3.format('.0%')))
 			.selectAll('text')
 			.style('font-size', '1.8em');
-
-		// Add the y axis and tick labels
-		let yaxisCurrent = svg
-			.append('g')
-			.attr('transform', `translate(${marginLeft},${y0(subdataTechPerYear[0].year)})`)
-			.attr('class', 'axis')
-			.call(d3.axisLeft(yCurrent).tickSizeOuter(0))
-			.call((g) => g.selectAll('.domain').remove())
-			.call((g) => g.selectAll('.tick line').remove())
-			.selectAll('text')
-			.style('font-size', '1.8em')
-			.on('mouseover', mouseOverLabels)
-			.on('mouseout', mouseout)
-			.on('mousemove', mousemove);
 
 		svg
 			.append('g')
@@ -400,11 +386,11 @@ export class techmix_sector {
 			}
 		}
 
-		function mousemove(d) {
+		function mousemove() {
 			tooltip.style('left', d3.event.pageX + 10 + 'px').style('top', d3.event.pageY - 20 + 'px');
 		}
 
-		function mouseout(d) {
+		function mouseout() {
 			tooltip.style('display', 'none');
 		}
 	}

--- a/src/js/time_line.js
+++ b/src/js/time_line.js
@@ -68,8 +68,7 @@ export class time_line {
 			scen_line_color = '#00c082';
 
 		// Declare text labels
-		let xtitle = '',
-			scen_label = 'Scenario',
+		let scen_label = 'Scenario',
 			port_label = 'Portfolio',
 			hoverover_value = 'Value: ',
 			footnote = '* start date of the analysis';

--- a/src/js/trajectory_alignment.js
+++ b/src/js/trajectory_alignment.js
@@ -1,6 +1,5 @@
 // src/js./trajectory_alignment.js
 import * as d3 from 'd3';
-import { rollups } from 'd3-array';
 import '../css/plot_styles.css';
 
 export class trajectory_alignment {
@@ -44,7 +43,7 @@ export class trajectory_alignment {
 
 		// Declare the chart dimensions and margins.
 		const width = 1000;
-		let height, paddingBetweenPlotsVertical, nrRowsMiniPlots;
+		let height, paddingBetweenPlotsVertical;
 		if ((technologies.length > 3) & (technologies.length <= 6)) {
 			height = 550;
 			paddingBetweenPlotsVertical = 60;
@@ -89,22 +88,6 @@ export class trajectory_alignment {
 			return;
 		}
 
-		const scenarios_to_include = [
-			'STEPS',
-			'APS',
-			'SDS',
-			'NZE_2050',
-			'CurPol',
-			'NDC-LTS',
-			'1.5C-Unif',
-			'ETP_SDS',
-			'NZE',
-			'IPR FPS 2021',
-			'1.5C',
-			'NDC_LTS',
-			'Reference',
-			'1.5\xb0C'
-		];
 		let ytitle = 'Production in ',
 			portfolio_label = 'Portfolio',
 			benchmark_label = 'Benchmark',
@@ -145,7 +128,6 @@ export class trajectory_alignment {
 			1 + Math.abs(x.domain().reduce((a, b) => a.getFullYear() - b.getFullYear()));
 
 		let subdataTech,
-			i,
 			group,
 			production_data,
 			benchmark_data,
@@ -160,7 +142,7 @@ export class trajectory_alignment {
 			area_paths_grp,
 			area_paths,
 			production_line_grp;
-		let production_line, dots_production, benchmark_line_grp, dots_benchmark, unit, tick_labels;
+		let production_line, benchmark_line_grp, unit, tick_labels;
 
 		technologies.forEach((item, index) => {
 			subdataTech = subdata.filter((d) => d.technology == item);
@@ -322,9 +304,9 @@ export class trajectory_alignment {
 				.attr('stroke-width', 1.5)
 				.attr('fill', 'none')
 				.attr('stroke', 'black')
-				.attr('d', (d) => production_line(production_data));
+				.attr('d', () => production_line(production_data));
 
-			dots_production = production_line_grp
+			production_line_grp
 				.selectAll('.dot')
 				.data(production_data)
 				.enter()
@@ -357,9 +339,9 @@ export class trajectory_alignment {
 					.attr('fill', 'none')
 					.attr('stroke', 'black')
 					.style('stroke-dasharray', '2,2')
-					.attr('d', (d) => benchmark_line(benchmark_data));
+					.attr('d', () => benchmark_line(benchmark_data));
 
-				dots_benchmark = benchmark_line_grp
+				benchmark_line_grp
 					.selectAll('.dot')
 					.data(benchmark_data)
 					.enter()


### PR DESCRIPTION
This PR is where things get a little spicy. I am simply removing every `var` and `import` that is unused!
There are a few categories here:
- The simplest is just tech debt, a `var` or function argument was defined (and probably used at some point) and later removed from he function body, but left in the body
- `vars` that are defined for their side-effects (you can just remove them and call the methods alone)
- unused package imports (self explanatory)

This PR affects the following plots: 
- pie_exploded
- tech_exposure
- tech_exposure_company
- techmix_sector
- timeline
- trajectory_alignment

I will post side-by-sides of these plots before and after to show they still render (and I have visually inspected them to ensure all interactivity still functions as expected)

@MonikaFu FYI

Relates to #96 
Towards #29 