### PR TITLE
💄 ignore complaints of shadowing `this`

### DIFF
--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -233,11 +233,11 @@ export class PieExploded {
 
 			again = false;
 			textLabels.each(function () {
-				thisLabel = this;
+				thisLabel = this; // eslint-disable-line
 				thisLabelDoc = d3.select(thisLabel);
 				y1 = thisLabelDoc.attr('y');
 				textLabels.each(function () {
-					thatLabel = this;
+					thatLabel = this; // eslint-disable-line
 					if (thisLabel == thatLabel) return;
 
 					thatLabelDoc = d3.select(thatLabel);


### PR DESCRIPTION
This is the only linter complaint that I didn't feel I understood well enough to fix, so I am just disabling the linter for these particular lines. 

I have created an issue to ensure that we figure out a solution for this down the road #102
