### PR TITLE
💄 make asset class name bold in Exposure Stats

### DIFF
--- a/src/js/exposure_stats.js
+++ b/src/js/exposure_stats.js
@@ -112,7 +112,8 @@ export class ExposureStatsTile {
 			.attr('transform', (d, i) => 'translate(0, ' + i * 15 + ')')
 			.text((d) => d)
 			.style('dominant-baseline', 'middle')
-			.style('text-anchor', 'end');
+			.style('text-anchor', 'end')
+			.style('font-weight', (d, i) => (i == 1 ? 'bold' : 'normal'));
 
 		function prcnt_format(num) {
 			if (num == 0) {


### PR DESCRIPTION
Effects of change:
<img width="324" alt="Screenshot 2024-12-03 at 12 36 39" src="https://github.com/user-attachments/assets/24a8ac18-c276-49dc-96f4-5911d931f2dd">

Closes #90 