### PR TITLE
💄 App Bar header aligns with RMI colours

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -7,3 +7,7 @@ html,
 body {
 	@apply h-full overflow-hidden;
 }
+.app-bar-custom {
+	background-color: rgb(var(--color-surface-800));
+	color: rgb(var(--theme-font-color-dark));
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -49,9 +49,9 @@
 <AppShell>
 	<svelte:fragment slot="header">
 		<!-- App Bar -->
-		<AppBar>
+		<AppBar class="app-bar-custom">
 			<svelte:fragment slot="lead">
-				<strong class="text-xl">PACTA Climate Alignment Tool</strong>
+				<strong class="text-xl app-bar-custom">PACTA Climate Alignment Tool</strong>
 			</svelte:fragment>
 			<svelte:fragment slot="trail">
 				<a


### PR DESCRIPTION
This is a minor (and reversible) customization to get the application header aligned with RMI-style. 
<img width="663" alt="Screenshot 2024-12-03 at 13 51 47" src="https://github.com/user-attachments/assets/aacc7804-d87b-4672-bf5a-207c41224041">

Towards #91 
