### PR TITLE
fix footnote to show correct scenario (techexp_comp)

### DIFF
--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -291,7 +291,7 @@ export class techexposure_company {
 
 		let footnote_label =
 			footnote_lab.befor_scen +
-			data_up.filter((d) => d.scenario != 'production').map((d) => d.scenario)[0] +
+			scenario_source + " " + scenario +
 			footnote_lab.after_scen +
 			data_up.map((d) => d.year)[0] +
 			footnote_lab.after_year;

--- a/src/js/techexposure_company.js
+++ b/src/js/techexposure_company.js
@@ -291,7 +291,9 @@ export class techexposure_company {
 
 		let footnote_label =
 			footnote_lab.befor_scen +
-			scenario_source + " " + scenario +
+			scenario_source +
+			' ' +
+			scenario +
 			footnote_lab.after_scen +
 			data_up.map((d) => d.year)[0] +
 			footnote_lab.after_year;


### PR DESCRIPTION
- closes #93 

`scenario` and `scenario_source` capture the currently selected values of the scenario and scenario source selectors, so it's easy to utilize that here

unlike `data_up`, `subdata_up` does not contain any scenario information, so it cannot be taken from there (as I tried in #105)

`data_up` only contains one year, so it's still possible to pull the correct year from it as before