### PR TITLE
🐛 fix deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
         run: |
           npm run build
 
+      - name: Copy in sample data
+        run: cp -r sample-data static/data
+
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Adds a small step to copy the `sample-data` back where we expect it. 

Broken by #109

(hard to test this one without merging it to `main` and seeing if the action works...)