### PR TITLE
remove aliasing of `this`

### DIFF
--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -220,10 +220,8 @@ export class PieExploded {
 
 		function relaxLabels() {
 			let again,
-				thisLabel,
 				thisLabelDoc,
 				y1,
-				thatLabel,
 				thatLabelDoc,
 				y2,
 				deltaY,

--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -232,18 +232,17 @@ export class PieExploded {
 				labelForLine;
 
 			again = false;
-			textLabels.each(function () {
-				thisLabel = this; // eslint-disable-line
-				thisLabelDoc = d3.select(thisLabel);
+			textLabels.each(function (idx1) {
+				thisLabelDoc = d3.select(this);
 				y1 = thisLabelDoc.attr('y');
-				textLabels.each(function () {
-					thatLabel = this; // eslint-disable-line
-					if (thisLabel == thatLabel) return;
 
-					thatLabelDoc = d3.select(thatLabel);
+				textLabels.each(function (idx2) {
+					thatLabelDoc = d3.select(this);
+					y2 = thatLabelDoc.attr('y');
+
+					if (idx1 == idx2) return;
 					if (thisLabelDoc.attr('text-anchor') != thatLabelDoc.attr('text-anchor')) return;
 
-					y2 = thatLabelDoc.attr('y');
 					deltaY = y1 - y2;
 					if (Math.abs(deltaY) > minLabelSpacing) return;
 

--- a/src/js/pie_exploded.js
+++ b/src/js/pie_exploded.js
@@ -219,15 +219,7 @@ export class PieExploded {
 		}
 
 		function relaxLabels() {
-			let again,
-				thisLabelDoc,
-				y1,
-				thatLabelDoc,
-				y2,
-				deltaY,
-				sign,
-				adjustment,
-				labelForLine;
+			let again, thisLabelDoc, y1, thatLabelDoc, y2, deltaY, sign, adjustment, labelForLine;
 
 			again = false;
 			textLabels.each(function (idx1) {


### PR DESCRIPTION
- closes #102

solved the 1st level `this` aliasing by passing through the index in each `.each()` loop and comparing the indices rather than comparing the elements (aliased `this`) themselves

otherwise follows suggestion in https://github.com/RMI-PACTA/pacta-dashboard-svelte/issues/102#issuecomment-2515396572