### PR TITLE
🙈 ignore `static/data` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules
 /build
 /test-results
 
+# Data
+/static/data
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
For local development, it is easier to just dump testing data into the `static` directory, but don't want ot commit that!
Relates to #109