### PR TITLE
🔥 HOTFIX: Change path for copying sample data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           npm run build
 
       - name: Copy in sample data
-        run: cp -r sample-data static/data
+        run: cp -r sample-data build/data
 
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Rather than copying the sample data to `static/data` (which would work prior to build), copy to `build/data`