### PR TITLE
add label y offset for start year portfolio labels

### DIFF
--- a/src/js/techmix_sector.js
+++ b/src/js/techmix_sector.js
@@ -273,7 +273,7 @@ export class techmix_sector {
 		// Add the y axis and tick labels
 		svg
 			.append('g')
-			.attr('transform', `translate(${marginLeft},${y0(subdataTechPerYear[0].year)})`)
+			.attr('transform', `translate(${marginLeft},${y0(subdataTechPerYear[0].year) - 20})`)
 			.attr('class', 'axis')
 			.call(d3.axisLeft(yCurrent).tickSizeOuter(0))
 			.call((g) => g.selectAll('.domain').remove())


### PR DESCRIPTION
- closes #86

To be honest, I don't know exactly why these labels need to be bumped up 20 pixels. It is clear that there's a larger space between the 2 bars in the top then there is between the bars below. I also know that a 20px y-offset was used in [pacta.portfolio.report/inst/jstechexposure_future.js](https://github.com/RMI-PACTA/pacta.portfolio.report/blob/24221e740e947a538702085093a5cb1aa67fa03c/inst/js/techexposure_future.js#L55), which I assume this was largely based on.

It does appear to have the intended effect though
<img width="559" alt="Screenshot 2024-12-04 at 17 10 15" src="https://github.com/user-attachments/assets/d9001b71-f58a-4d93-92fa-5fd79d17ea89">
