### PR TITLE
nudege the y-axis title down on the emissions timeline

### DIFF
--- a/src/js/time_line.js
+++ b/src/js/time_line.js
@@ -154,7 +154,7 @@ export class time_line {
 			.append('text')
 			.attr(
 				'transform',
-				`translate(${marginLeft / 2},${(height - marginBottom) / 2 + 15}) rotate(-90)`
+				`translate(${marginLeft / 2},${(height - marginBottom) / 2 + 25}) rotate(-90)`
 			)
 			.attr('x', 0)
 			.attr('y', 0)


### PR DESCRIPTION
- closes #87 

Since the height is adaptive/relative, it made more sense to nudge the whole y-axis title down a bit.

<img width="547" alt="Screenshot 2024-12-05 at 08 57 05" src="https://github.com/user-attachments/assets/cf7e4a20-c083-4570-9217-81826d69c06c">
