### PR TITLE
📝 remove key features bullets

### DIFF
--- a/src/routes/company_view.svelte
+++ b/src/routes/company_view.svelte
@@ -394,20 +394,7 @@
 					climate-related decisions, such as investment selection, engagement, or exclusion, and
 					helps shape targeted climate strategies.
 					<br /><br />
-					Key features in this section:
-					<br /><br />
 				</p>
-				<ul class="list-disc">
-					<li>
-						<strong>Critical Players</strong>: Identify the most influential companies in your
-						portfolio’s alignment with climate goals.
-					</li>
-					<li>
-						<strong>Leaders and Laggards</strong>: Discover which companies are at the forefront of
-						adopting low-carbon alternatives and which are lagging behind.
-					</li>
-				</ul>
-				<br />
 			</div>
 			<div class="analysis-intro-stats sm:col-span-3">
 				<div class="exposure-stats" id="exposure-stats"></div>

--- a/src/routes/pacta_intro.svelte
+++ b/src/routes/pacta_intro.svelte
@@ -10,15 +10,8 @@
 		insights into how well your portfolio is positioned to align with multiple climate objectives.
 		This section provides a high-level overview of the dashboard's functionalities, setting the
 		stage for in-depth analysis across various levels—from portfolio-wide metrics to
-		company-specific evaluations. Key features in this section:
-		<ul class="list-disc p-4">
-			<li><strong>Overview of the methodology</strong> behind the PACTA analysis;</li>
-			<li><strong>Sector and asset class</strong> coverage in the analysis;</li>
-			<li>
-				<strong>Metrics used to assess alignment with climate targets </strong> (e.g., emission intensity,
-				future technology)
-			</li>
-		</ul>
+		company-specific evaluations.
+		<br /><br />
 		To explore more detailed content for each section below, simply click on the titles. A dropdown will
 		appear with further explanations and insights for each topic. This allows you to dig deeper into
 		the information that matters most to you.

--- a/src/routes/portfolio_view.svelte
+++ b/src/routes/portfolio_view.svelte
@@ -153,26 +153,7 @@
 					<br /> <br />
 					You can hover over the graphs to get more in-depth insights of your portfolio-level analysis.
 					<br /> <br />
-					Key features in this section:
 				</p>
-				<br />
-				<ul class="list-disc">
-					<li>
-						<strong>Scope of Analysis</strong>: Understand which holdings are included in the
-						assessment and if it is a direct or indirect investment.
-					</li>
-					<li>
-						<strong>Sector Coverage</strong>: First overview of the exposure to climate-relevant
-						sectors and their technologies, as a share of the AUM (assets under management) of the
-						portfolio
-					</li>
-					<li>
-						<strong>Emissions Coverage</strong>: Get an estimate of how much of your portfolio’s
-						emissions are addressed in the analysis, as well as an overview of your portfolio
-						absolute emissions.
-					</li>
-				</ul>
-				<br />
 			</div>
 		</div>
 		<div class="analysis-content grid sm:grid-cols-12 p-4">

--- a/src/routes/sector_view.svelte
+++ b/src/routes/sector_view.svelte
@@ -466,25 +466,6 @@
 				this section helps you understand your portfolio's positioning in key sectors for the global
 				transition to a low-carbon economy.
 				<br /><br />
-				Key features in this section:
-				<br /><br />
-				<ul class="list-disc">
-					<li>
-						<strong>Sector Exposure</strong>: Review the portfolio's exposure to a specific sector,
-						as well as its exposure to sector-specific technologies.
-					</li>
-					<li>
-						<strong>Climate Scenario Alignment</strong>: Understand how the production plans of
-						investee companies in this sector align with different climate pathways.
-					</li>
-					<li>
-						<strong>Benchmark Comparison</strong>: See how your portfolio's performance compares to
-						market benchmarks.
-					</li>
-				</ul>
-				<br />
-				For deeper insights into the methodology behind these analyses, please refer to the
-				<a class="anchor" href="https://rmi.gitbook.io/pacta-knowledge-hub">PACTA Knowledge Hub</a>.
 			</div>
 			<div class="analysis-intro-stats sm:col-span-3 p-0">
 				<div class="exposure-stats" id="exposure-stats"></div>


### PR DESCRIPTION
In this PR, I remove the superfluous "key features" sections, as well as a superfluous link to the "PACTA knowledge hub".

Towards getting the whole dashboard to be viewable in a single screen.

Closes #146 
Closes #147 