### PR TITLE
keep the tab bar fixed at the top of the page when scrolling

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -11,3 +11,7 @@ body {
 	background-color: rgb(var(--color-surface-800));
 	color: rgb(var(--theme-font-color-dark));
 }
+.tab-list {
+	position: fixed;
+	background-color: rgb(var(--color-surface-100));
+}

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -11,7 +11,3 @@ body {
 	background-color: rgb(var(--color-surface-800));
 	color: rgb(var(--theme-font-color-dark));
 }
-.tab-list {
-	position: fixed;
-	background-color: rgb(var(--color-surface-100));
-}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,9 +8,8 @@
 	let tabSet: number = 1;
 </script>
 
-<span>
-<svelte:fragment slot="header">
 <TabGroup>
+<svelte:fragment slot="header">
 	<Tab bind:group={tabSet} name="about" value={0}>About PACTA</Tab>
 	<Tab bind:group={tabSet} name="portfolio_view" value={1}>Portfolio-level Overview</Tab>
 	<Tab bind:group={tabSet} name="sector_view" value={2}>Sector-level Analysis</Tab>
@@ -29,6 +28,5 @@
 			<p>Tab not found</p>
 		{/if}
 	</svelte:fragment>
-</TabGroup>
 </svelte:fragment>
-</span>
+</TabGroup>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	let tabSet: number = 1;
 </script>
 
+<svelte:fragment slot="header">
 <TabGroup>
 	<Tab bind:group={tabSet} name="about" value={0}>About PACTA</Tab>
 	<Tab bind:group={tabSet} name="portfolio_view" value={1}>Portfolio-level Overview</Tab>
@@ -28,3 +29,4 @@
 		{/if}
 	</svelte:fragment>
 </TabGroup>
+</svelte:fragment>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,9 @@
 	let tabSet: number = 1;
 </script>
 
-<TabGroup>
+<AppShell>
 <svelte:fragment slot="header">
+<TabGroup>
 	<Tab bind:group={tabSet} name="about" value={0}>About PACTA</Tab>
 	<Tab bind:group={tabSet} name="portfolio_view" value={1}>Portfolio-level Overview</Tab>
 	<Tab bind:group={tabSet} name="sector_view" value={2}>Sector-level Analysis</Tab>
@@ -28,5 +29,6 @@
 			<p>Tab not found</p>
 		{/if}
 	</svelte:fragment>
-</svelte:fragment>
 </TabGroup>
+</svelte:fragment>
+</AppShell>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	let tabSet: number = 1;
 </script>
 
+<span>
 <svelte:fragment slot="header">
 <TabGroup>
 	<Tab bind:group={tabSet} name="about" value={0}>About PACTA</Tab>
@@ -30,3 +31,4 @@
 	</svelte:fragment>
 </TabGroup>
 </svelte:fragment>
+</span>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Tab, TabGroup } from '@skeletonlabs/skeleton';
+	import { AppShell } from '@skeletonlabs/skeleton';
 	import PactaIntro from './about.svelte';
 	import PortfolioView from './portfolio_view.svelte';
 	import SectorView from './sector_view.svelte';


### PR DESCRIPTION
- closes #94 

based on @jdhoffa's suggestion here https://github.com/RMI-PACTA/pacta-dashboard-svelte/issues/94#issuecomment-2515377985

not sure if this is the best way to do this