### PR TITLE
Delete `LICENSE` file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,0 @@
-YEAR: 2024
-COPYRIGHT HOLDER: pacta-dashboard-svelte authors


### PR DESCRIPTION
We only actually need the `LICENSE.md` here. 
The `LICENSE` file is superfluous, and is confusing GitHubs license detection process.