### PR TITLE
fix tab bar position to the bottom of the header when scrolling

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -13,6 +13,7 @@ body {
 }
 .tab-list {
 	position: fixed;
+	z-index: 1;
 	top: 75px;
 	width: 100%;
 	background-color: rgb(var(--color-surface-100));

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -11,3 +11,9 @@ body {
 	background-color: rgb(var(--color-surface-800));
 	color: rgb(var(--theme-font-color-dark));
 }
+.tab-list {
+	position: fixed;
+	top: 75px;
+	width: 100%;
+	background-color: rgb(var(--color-surface-100));
+}


### PR DESCRIPTION
- closes #94 

based on @jdhoffa's suggestion here https://github.com/RMI-PACTA/pacta-dashboard-svelte/issues/94#issuecomment-2515377985, with additional CSS to complete the job

⚠️ of course, this gets wonky if the browser window is narrow enough to make the header wrap the text and cause it to use an extra line... position relative to the header would be ideal, but not sure how to achieve that