### PR TITLE
fix: import rmi_theme with `ts` extension

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'tailwindcss';
 import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
 import { skeleton } from '@skeletonlabs/tw-plugin';
-import { rmi_theme } from './src/rmi_theme';
+import { rmi_theme } from './src/rmi_theme.ts';
 
 export default {
 	darkMode: 'class',


### PR DESCRIPTION
This started to cause bugs for me locally when trying to run `npm run dev`.