### PR TITLE
Resolve security vulnerability pertaining to `devalue` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -771,10 +771,11 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.25",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
-			"integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
-			"dev": true
+			"version": "1.0.0-next.29",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.18.1",
@@ -1011,6 +1012,23 @@
 				"tailwindcss": ">=3.0.0"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@sveltejs/acorn-typescript": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^8.9.0"
+			}
+		},
 		"node_modules/@sveltejs/adapter-auto": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.2.tgz",
@@ -1024,33 +1042,35 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.2.tgz",
-			"integrity": "sha512-/EBFydZDwfwFfFEuF1vzUseBoRziwKP7AoHAwv+Ot3M084sE/HTVBHf9mCmXfdM9ijprY5YEugZjleflncX5fQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.9.tgz",
+			"integrity": "sha512-aytHXcMi7lb9ljsWUzXYQ0p5X1z9oWud2olu/EpmH7aCu4m84h7QLvb5Wp+CFirKcwoNnYvYWhyP/L8Vh1ztdw==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.5.18",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.18.tgz",
-			"integrity": "sha512-+g06hvpVAnH7b4CDjhnTDgFWBKBiQJpuSmQeGYOuzbO3SC3tdYjRNlDCrafvDtKbGiT2uxY5Dn9qdEUGVZdWOQ==",
+			"version": "2.43.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.43.4.tgz",
+			"integrity": "sha512-GfvOq3A/qMRhj2L9eKjxaI8FLqZDh5SY74YzhRKT//u2AvQw96ksEfjuHviC4jg9U08mBVB0Y47EwEJHO4BB4Q==",
 			"dev": true,
-			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/cookie": "^0.6.0",
+				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.0.0",
-				"esm-env": "^1.0.0",
-				"import-meta-resolve": "^4.1.0",
+				"devalue": "^5.3.2",
+				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.6.0",
-				"sirv": "^2.0.4",
-				"tiny-glob": "^0.2.9"
+				"sirv": "^3.0.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -1059,10 +1079,23 @@
 				"node": ">=18.13"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0",
+				"@opentelemetry/api": "^1.0.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.3"
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
 			}
+		},
+		"node_modules/@sveltejs/kit/node_modules/esm-env": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
 			"version": "3.1.1",
@@ -1488,10 +1521,11 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2399,10 +2433,11 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.0.0.tgz",
-			"integrity": "sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==",
-			"dev": true
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+			"integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
@@ -3047,12 +3082,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globalyzer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-			"dev": true
-		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3072,12 +3101,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/globrex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-			"dev": true
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
@@ -3627,10 +3650,11 @@
 			}
 		},
 		"node_modules/mrmime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-			"integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -4599,17 +4623,18 @@
 			}
 		},
 		"node_modules/sirv": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-			"integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.24",
 				"mrmime": "^2.0.0",
 				"totalist": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/slash": {
@@ -5212,16 +5237,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/tiny-glob": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-			"dev": true,
-			"dependencies": {
-				"globalyzer": "0.1.0",
-				"globrex": "^0.1.2"
-			}
-		},
 		"node_modules/tinybench": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
@@ -5281,6 +5296,7 @@
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
 			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}


### PR DESCRIPTION
- Bump `@sveltejs/adapter-static` from `3.0.2` to `3.0.9`
- Bump `@sveltejs/kit` from `2.5.18` to `2.43.4`

as a side-effect, this bumps [devalue](https://github.com/sveltejs/devalue) from 5.0.0 to 5.3.2, which resolves https://github.com/RMI-PACTA/pacta-dashboard-svelte/security/dependabot/21

Supersedes #186 